### PR TITLE
Add infra to be deployed via secure pipelines

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,65 @@
+name: Error Page Infra deployment
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true  # this caches installation but is only available on Linux x86-64 runners
+
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ERROR_PAGE_GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Install python dependencies
+        run: |
+          mkdir -p uploadErrorPageLambda/python
+          python -m pip install -r uploadErrorPageLambda/requirements.txt \
+          --platform manylinux2014_x86_64 \
+          --target="uploadErrorPageLambda" \
+          --implementation cp \
+          --python-version 3.12 \
+          --only-binary=:all:
+
+      - name: copy index.html
+        run: cp index.html uploadErrorPageLambda
+
+      - name: SAM validate
+        run: sam validate
+
+      - name: SAM build and test
+        run: sam build
+
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        with:
+          artifact-bucket-name: ${{ secrets.ERROR_PAGE_ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,110 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+
+Description: Infrastructure to host the Cloudfront error page
+
+Parameters:
+  CodeSigningConfigArn:
+    Type: String
+    Description: >
+      The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Default: "none"
+  PermissionsBoundary:
+    Type: String
+    Description: >
+      The ARN of the permissions boundary to apply to any role created by the template
+    Default: "none"
+
+Conditions:
+  UseCodeSigning:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref CodeSigningConfigArn
+          - "none"
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
+Globals:
+  Function:
+    CodeSigningConfigArn: !If
+      - UseCodeSigning
+      - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
+
+Resources:
+  CFErrorPageBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      VersioningConfiguration:
+        Status: "Enabled"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      Tags:
+        - Key: Source
+          Value: "govuk-one-login/static-error-pages/cloudformation/template"
+
+  CFErrorPageBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref CFErrorPageBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Sid: AllowCloudFrontServicePrincipal
+          Action: s3:GetObject
+          Effect: Allow
+          Resource: !Sub ${CFErrorPageBucket.Arn}/*
+          Principal:
+            Service: cloudfront.amazonaws.com
+          Condition: 
+            StringEquals: 
+              "aws:SourceOrgID": "o-dpp53lco28"
+
+  StaticSiteInvoke:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      BucketName: !Ref CFErrorPageBucket
+      ServiceToken: !GetAtt StaticSiteUploadFunction.Arn
+      FunctionName: !Ref StaticSiteUploadFunction.Version
+
+  StaticSiteUploadFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Architectures: 
+       - x86_64
+      #checkov:skip=CKV_AWS_117:vpc not required for this simple S3 upload
+      #checkov:skip=CKV_AWS_116:dlq not required for this simple S3 upload function
+      #checkov:skip=CKV_AWS_173:encryption not required
+      #checkov:skip=CKV_AWS_115:concurency setup not required
+      CodeUri: uploadErrorPageLambda
+      AutoPublishAlias: LatestVersion
+      FunctionName: upload-cf-error-page
+      Runtime: python3.12
+      Timeout: 5
+      Handler: uploadStaticSite.handler
+      Policies:
+        - S3WritePolicy:
+            BucketName: !Ref CFErrorPageBucket
+Outputs:
+  S3BucketSecureURL:
+    Value: !Join 
+      - ''
+      - - 'https://'
+        - !GetAtt 
+          - CFErrorPageBucket
+          - DomainName
+    Description: Name of S3 bucket to hold website content

--- a/uploadErrorPageLambda/requirements.txt
+++ b/uploadErrorPageLambda/requirements.txt
@@ -1,0 +1,2 @@
+crhelper
+boto3

--- a/uploadErrorPageLambda/uploadStaticSite.py
+++ b/uploadErrorPageLambda/uploadStaticSite.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+from crhelper import CfnResource
+
+import logging
+import boto3
+
+logger = logging.getLogger(__name__)
+# Initialise the helper, all inputs are optional, this example shows the defaults
+helper = CfnResource(json_logging=False, log_level='DEBUG', boto_level='CRITICAL', sleep_on_delete=120, ssl_verify=None)
+
+try:
+  s3 = boto3.resource('s3')
+  logger.info("Created boto3 S3 resource")
+
+  with open("index.html") as f:
+    logger.info("Able to open index.html")
+
+except Exception as e:
+  helper.init_failure(e)
+
+@helper.create
+@helper.update
+def updateBucket(event, context):
+  logger.info("Got Create or Update")
+  properties = event["ResourceProperties"]
+  bucket = s3.Bucket(properties["BucketName"])
+
+  try:
+    with open("index.html", 'rb') as f:
+      bucket.put_object(Key='cloudfront-error/index.html', Body=f, ContentType='text/html')
+  except Exception:
+    logger.critical('Could not upload to S3')
+    raise
+
+
+@helper.delete
+def no_op(_, __):
+  pass
+
+def handler(event, context):
+  helper(event, context)


### PR DESCRIPTION
The github workflow builds the python dependencies, and copies the index.html into the lambda folder. It will need the role from the deployed in AWS secure pipeline adding to the gh secrets.

This is then packaged up, signed and placed in the artifact bucket (entrypoint of the secure pipeline)

When this template is deployed an S3 bucket is created with the OAC required for our cloudfronts to get objects from it. A custom resource runs the lambda which copies in the index.html file to the bucket, and sets the correct content type to be served by cf.

Currently the error page can be observed by loading https://cloudfront-estimate.dev.platform.sandpit.account.gov.uk

Future work will be to inline the assets into the html file in the work flow added here, and also add tests against the html to ensure it is ok before release