### PR TITLE
Add doctype and external link accessibility fix

### DIFF
--- a/src/500.html
+++ b/src/500.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
@@ -46,7 +47,7 @@
               <p class="govuk-body">If that does not work then you can try again later.</p>
 
               <p class="govuk-body">
-                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status</a>
+                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status (opens in new tab)</a>
               </p>
 
             </div>

--- a/src/502.html
+++ b/src/502.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
@@ -46,7 +47,7 @@
               <p class="govuk-body">If that does not work then you can try again later.</p>
 
               <p class="govuk-body">
-                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status</a>
+                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status (opens in new tab)</a>
               </p>
 
             </div>

--- a/src/503.html
+++ b/src/503.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
@@ -46,7 +47,7 @@
               <p class="govuk-body">If that does not work then you can try again later.</p>
 
               <p class="govuk-body">
-                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status</a>
+                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status (opens in new tab)</a>
               </p>
 
             </div>

--- a/src/504.html
+++ b/src/504.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
@@ -46,7 +47,7 @@
               <p class="govuk-body">If that does not work then you can try again later.</p>
 
               <p class="govuk-body">
-                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status</a>
+                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status (opens in new tab)</a>
               </p>
 
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
@@ -46,7 +47,7 @@
               <p class="govuk-body">If that does not work then you can try again later.</p>
 
               <p class="govuk-body">
-                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status</a>
+                <a href="https://status.account.gov.uk/" rel="noopener" target="_blank" class="govuk-link govuk-body" id="statusPageLink">GOV.UK One Login service status (opens in new tab)</a>
               </p>
 
             </div>


### PR DESCRIPTION
Two small additions to the HTML code for all the pages in this repo:
* Adding the HTML5 `DOCTYPE` to assist browsers in rendering the page
* Adding `opens in a new tab` to the links to the status page, as [required by the GDS Design System](https://design-system.service.gov.uk/styles/links/#opening-links-in-a-new-tab)