### PR TITLE
Test sonarcloud accessibility report for HTML and Nunjucks files

### DIFF
--- a/src/accessibility-test.html
+++ b/src/accessibility-test.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Extremely inaccessible site</title>
+  <style>
+    body {background: #eee; color: #ddd; font-family:sans-serif;}
+    a {color: #ddd;}
+  </style>
+</head>
+<body>
+<a href="#" aria-labelledby="false">
+          <h1 tabindex="3" aria-controls>
+
+            This is an inaccessible site</h2>
+                 <fieldset>
+            <img src="test.jpg">
+            <form>
+            <input type="text">
+            </form>
+                 </fieldset>
+            <p>This is some content</p>
+            <table><tr><td>Items</tr></table>
+            <h4>This is text</h4>
+</body>
+</html>

--- a/src/accessibility-test.njk
+++ b/src/accessibility-test.njk
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Extremely inaccessible site</title>
+  <style>
+      body {background: #eee; color: #ddd; font-family:sans-serif;}
+      a {color: #ddd;}
+  </style>
+</head>
+<body>
+<a href="#" aria-labelledby="false">
+  <h1 tabindex="3" aria-controls>
+
+    {{ siteContent }}</h2>
+    <fieldset>
+      <img src="test.jpg">
+      <form>
+        <input type="text">
+      </form>
+    </fieldset>
+    <p>{{ pageContent }}</p>
+    <table><tr><td>Items</tr></table>
+    <h4>This is text</h4>
+</body>
+</html>


### PR DESCRIPTION
This is a throwaway PR to check Sonarcloud accessibility checks. Specifically:

* What sort of report is created?
* Is the PR blocked from being merged?
* Does sonarcloud check HTML in a file without a `.html` extension?